### PR TITLE
Add support for scanDirs globbing

### DIFF
--- a/tasks/lingua.js
+++ b/tasks/lingua.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
     if ('extract' === this.target) {
       var args = 'extract -F babel.cfg -k _n:1,2 -k _ -o'.split(' ');
       args.push(this.data.potDest);
-      args = args.concat(this.data.scanDirs);
+      args = args.concat(grunt.file.expand({filter:'isDirectory'}, this.data.scanDirs));
       var child = grunt.util.spawn({
         cmd: 'pybabel',
         args: args,


### PR DESCRIPTION
It is now possible to say

``` js
    lingua: {
      extract: {
        potDest: 'translations/messages.pot', // dest path must exist
        scanDirs: [
             // everything recursively under app/
             '<%= yeoman.app %>/**'
             // but not 3rd party components
           , '!<%= yeoman.app %>/bower_components/**'
        ]
```
